### PR TITLE
通常投稿の検索を実装

### DIFF
--- a/copla-vue/src/components/TrendMenu.vue
+++ b/copla-vue/src/components/TrendMenu.vue
@@ -12,7 +12,8 @@
         >
           <v-list>
             <v-list-item title="">
-              <h1>Real Time</h1>
+              <h1>Copla News</h1>
+              <h2>忘れ物掲示とか, UNIPAで見逃されそうな掲示情報とか</h2>
             </v-list-item>
           </v-list>
         </v-navigation-drawer>


### PR DESCRIPTION
・通常投稿のみ検索を実行
-複数単語に対応　半角または全角スペース区切りで入力
-投稿本文, ジャンル, ユーザ名を探索

返信は該当する返信の元投稿と、
その元投稿に属する全ての返信を取得する複雑性のため、実装を保留。